### PR TITLE
Only recompile if modified file ends with .less

### DIFF
--- a/src/leiningen/less/nio.clj
+++ b/src/leiningen/less/nio.clj
@@ -197,8 +197,9 @@
     (try
       (loop []
         (let [key (.take watcher)]
-          (callback)
-          (.pollEvents key)
+          (when (some #(-> % .context .toString (.endsWith ".less"))
+                      (.pollEvents key))
+            (callback))
           (.reset key)
           (recur)))
       (catch InterruptedException ex


### PR DESCRIPTION
In some cases it's helpful to have .less files mixed in with other types - this is a harmless filter for the `auto` task that only recompiles when the modified file has the .less extension.