### PR TITLE
Allow src-paths to refer to individual less files

### DIFF
--- a/src/leiningen/less/nio.clj
+++ b/src/leiningen/less/nio.clj
@@ -178,12 +178,14 @@
     (->>
       (for [^Path src-path src-paths
             ^Path src (remove private? (filter less? (descendents src-path)))]
-        (let [dst ^Path (.resolve target-path (.relativize src-path src))
+        (let [dst-filename (if (less? src-path)
+                             (str (.getFileName src-path))
+                             (.relativize src-path src))
+              dst ^Path (.resolve target-path dst-filename)
               [_ fname ext] (re-matches #"^(.+)[.]([^.]+)$" (.toString dst))
               dst (.resolve (.getParent dst) (format "%s.%s" fname "css"))]
           (when fname {:src src :dst dst})))
-      (remove empty?)
-      )))
+      (remove empty?))))
 
 (defn watch-resources [project paths callback]
   (let [^WatchService watcher (.newWatchService (FileSystems/getDefault))]

--- a/src/leiningen/less/nio.clj
+++ b/src/leiningen/less/nio.clj
@@ -191,7 +191,9 @@
   (let [^WatchService watcher (.newWatchService (FileSystems/getDefault))]
     (println "Found {less} source paths: ")
     (doseq [path paths
-            child (descendents directory? path)]
+            child (descendents directory? (if (less? path)
+                                            (.getParent path)
+                                            path))]
       (println (format "  %s" (fstr project child)))
       (.register ^Path child watcher watch-opts-cdm watch-modifiers))
     (println "Watching for changes...")


### PR DESCRIPTION
It can be useful to ensure that only a single less file (usually a "root" less file that contains a large amount of @imports) is compiled, rather than all less files in a path and it's descendents.  

This can actually be a workaround for #9 (that @tangrammer eluded to); instead of having the bootstrap less failures fail the build, only build a single (or multiple) "root" less files like thus:

src/less/my-css.less:
```less
@import bootstrap/bootstrap.less
@import some-other-file.less
```
project.clj
```clojure
  :less {:source-paths ["src/less/my-css.less"]
           :target-path "resources/public/css"}
```

I also added a change to ensure that the ```auto``` task watches the parent directory of any less files specified in ```src-paths``` - which isn't ideal, but will at least force a recompile of the src less file if _something_ changes thats _likely_ to affect the file.