### PR TITLE
support for :target-files added.

### DIFF
--- a/src/leiningen/less.clj
+++ b/src/leiningen/less.clj
@@ -19,13 +19,13 @@
 
 (defn- run-compiler
   "Run the lesscss compiler."
-  [project {:keys [source-paths target-path] :as config} watch?]
+  [project {:keys [source-paths target-path target-files] :as config} watch?]
   (engine/with-engine "javascript"
     (compiler/initialise)
     (println "Compiling {less} css:")
     (let [units (nio/compilation-units source-paths target-path)
           on-error (if watch? report-error abort-on-error)
-          compile (partial compiler/compile-project project units on-error)]
+          compile (partial compiler/compile-project project units target-files on-error)]
       (if watch?
         (nio/watch-resources project source-paths compile)
         (compile))
@@ -52,9 +52,7 @@
    (let [config (config project)]
      (case subtask
        "once" (apply once project config args)
-       "auto" (apply auto project config args)
-       )))
-  )
+       "auto" (apply auto project config args)))))
 
 (defn compile-hook [task & args]
   (apply task args)

--- a/src/leiningen/less/compiler.clj
+++ b/src/leiningen/less/compiler.clj
@@ -36,10 +36,17 @@
 
 (defn compile-project
   "Take a normalised project configuration and a sequence of src/dst pairs, compiles each pair."
-  [project units on-error]
+  [project units target-files on-error]
   (doseq [{:keys [^Path src ^Path dst]} units]
-    (println (format "%s => %s" (nio/fstr project src) (nio/fstr project dst)))
-    (try
-      (compile-resource src dst)
-      (catch LessError ex
-             (on-error ex)))))
+    (let [source      (nio/fstr project src)
+          destination (nio/fstr project dst)]
+      (if (some #(= source %) target-files)
+        (do (println (format "%s => %s" source destination))
+            (try
+              (compile-resource src dst)
+              (catch LessError ex
+                (on-error ex))))
+        (println (str "Skiping " source))))
+
+)
+  )

--- a/src/leiningen/less/compiler.clj
+++ b/src/leiningen/less/compiler.clj
@@ -34,19 +34,22 @@
                         (escape-string (nio/absolute dst)))))
 
 
+(defn- compile
+  [src dst on-error]
+  (try
+    (compile-resource src dst)
+    (catch LessError ex
+      (on-error ex))))
+
 (defn compile-project
   "Take a normalised project configuration and a sequence of src/dst pairs, compiles each pair."
   [project units target-files on-error]
   (doseq [{:keys [^Path src ^Path dst]} units]
     (let [source      (nio/fstr project src)
           destination (nio/fstr project dst)]
-      (if (some #(= source %) target-files)
-        (do (println (format "%s => %s" source destination))
-            (try
-              (compile-resource src dst)
-              (catch LessError ex
-                (on-error ex))))
-        (println (str "Skiping " source))))
-
-)
-  )
+      (if (nil? target-files)
+        (compile src dst on-error)
+        (if (some #(= source %) target-files)
+          (do (println (format "%s => %s" source destination))
+              (compile src dst on-error))
+          (println (str "Skiping " source)))))))

--- a/src/leiningen/less/config.clj
+++ b/src/leiningen/less/config.clj
@@ -9,6 +9,7 @@
                         (map (partial nio/resolve root))
                         (map nio/absolute)
                         (filter nio/exists?) vec)
+     :target-files (->> (get raw-config :target-files))
      :target-path (->> (get raw-config :target-path (get project :target-path nil))
                        (nio/resolve root)
                        (nio/absolute))}))


### PR DESCRIPTION
Compiling all the `less` files into css is not the solution because most of the `less` files are going to be imported into other files so compiling them is not correct. So I added the support for `:target-files` configuration. It should be a `vector` of relative file paths of the main less files ( files to compile ). For example in case of twitter bootstrap the `:target-files` would be something like this:

``` clojure
  :less {:source-paths ["resources/less"]
         :target-files ["resources/less/bootstrap/bootstrap.less" "resources/less/dashboard/style.less"]
         :target-path  "resources/public/css"}
```
